### PR TITLE
Use dogstatsd gem for event logging

### DIFF
--- a/ganbaru.gemspec
+++ b/ganbaru.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'thor', '~> 0.19.1'
   spec.add_dependency 'progress_bar'
   spec.add_dependency 'activesupport'
-  spec.add_dependency 'statsd-instrument'
+  spec.add_dependency 'dogstatsd-ruby'
 
   spec.add_development_dependency 'bundler', '~> 1.12'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lib/ganbaru/cli.rb
+++ b/lib/ganbaru/cli.rb
@@ -2,7 +2,6 @@
 require 'thor'
 require 'message_queue'
 require 'redis_client'
-require 'track/metrics'
 
 module Ganbaru
   class Cli < Thor
@@ -28,7 +27,6 @@ module Ganbaru
     LONGDESC
 
     def worker
-      Track::Metrics.worker(options[:id])
       Ganbaru::Worker.new(queue: queue, formatter: options[:formatter]).run
     end
 

--- a/lib/ganbaru/leader.rb
+++ b/lib/ganbaru/leader.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'redis_client'
+require 'track/metrics'
 
 module Ganbaru
   class Leader
@@ -9,6 +10,7 @@ module Ganbaru
     end
 
     def run(dir, shuffle: false)
+      Track::Metrics.event('Leader run', 'Ganbaru Leader started')
       puts "Test ID: #{@queue.id}"
       puts "Scanning #{dir}..."
 

--- a/lib/ganbaru/worker.rb
+++ b/lib/ganbaru/worker.rb
@@ -3,6 +3,7 @@
 require 'pp'
 require 'runners/rspec/executor'
 require 'runners/errors'
+require 'track/metrics'
 require 'track/progress'
 
 module Ganbaru
@@ -17,13 +18,16 @@ module Ganbaru
     end
 
     def run
-      loop do
-        break unless spec = run_spec
-        @specs_run << spec
-      end
+      Track::Metrics.event('Worker run', 'Ganbaru Worker started')
+      Track::Metrics.time('worker.run.time') do
+        loop do
+          break unless spec = run_spec
+          @specs_run << spec
+        end
 
-      @queue.destroy!
-      @specs_run
+        @queue.destroy!
+        @specs_run
+      end
     end
 
     def run_spec

--- a/lib/runners/rspec/executor.rb
+++ b/lib/runners/rspec/executor.rb
@@ -2,6 +2,7 @@
 require 'rspec'
 require 'runners/errors'
 require 'runners/rspec/result'
+require 'track/metrics'
 
 module Runners
   module Rspec
@@ -17,6 +18,10 @@ module Runners
         err = StringIO.new
         @runner.run(['-f', 'j', specs], err, @output)
         process_result(specs)
+        Track::Metrics.increment('rspec.executor.run.success')
+      rescue Runners::FailedTestError => e
+        Track::Metrics.increment('rspec.executor.run.fail')
+        raise
       ensure
         @rspec.clear_examples
       end


### PR DESCRIPTION
Use dogstatsd gem for event metrics.

It means calling the statsd methods directly where we want to instrument, but we may as well use the Datadog gem for Datadog graphs.